### PR TITLE
Support `pip install git+`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools >= 61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+dynamic = ["version"]
+name = "jello"
+readme = "README.md"
+description = "A Python script for wrapping Jellyfish (a fork of Jelly) so you can more easily play with the language."
+
+[project.scripts]
+jello = "jello.jello:main"
+
+[tool.setuptools]
+packages = ["jello"]
+
+[tool.setuptools.package-dir]
+jello = "src"
+

--- a/src/algorithm.py
+++ b/src/algorithm.py
@@ -1,8 +1,8 @@
 
 import re
 
-import draw
-import utils
+from . import draw
+from . import utils
 from colorama import Fore
 
 advisements = {

--- a/src/arity_notation.py
+++ b/src/arity_notation.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-import draw
-import utils
+from . import draw
+from . import utils
 from colorama import Fore
 from prompt_toolkit import prompt
 from prompt_toolkit.completion import WordCompleter

--- a/src/draw.py
+++ b/src/draw.py
@@ -1,10 +1,10 @@
 
 from itertools import takewhile
 
-import utils
+from . import utils
 from colorama import Fore, Style
-from grid import Grid
-from utils import Chain, Quick, Separator
+from .grid import Grid
+from .utils import Chain, Quick, Separator
 
 INITIAL_INDENT = 14
 

--- a/src/jello.py
+++ b/src/jello.py
@@ -5,18 +5,18 @@ import subprocess
 from functools import partial
 from itertools import permutations
 
-import algorithm
-import arity_notation
-import draw
-import tokens
-import utils
+from . import algorithm
+from . import arity_notation
+from . import draw
+from . import tokens
+from . import utils
 from colorama import Fore, init
-from grid import Grid
+from .grid import Grid
 from prompt_toolkit import prompt
 from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.shortcuts import CompleteStyle
-from utils import Chain, Quick, Separator
+from .utils import Chain, Quick, Separator
 
 
 def clear_screen():
@@ -123,7 +123,7 @@ def process_combinations(arg, out, combinations):
         if x == out:
             print(f"{arg} :: {keyword1} {keyword2} -> {x}")
 
-if __name__ == "__main__":
+def main():
     init()  # for colorama
 
     print("🟢🟡🔴 Jello 🔴🟡🟢\n")
@@ -214,3 +214,6 @@ if __name__ == "__main__":
             color = Fore.GREEN if "algorithm" in str(e) else Fore.RED
             draw.cprint(f"    {e}", color, True)
             # noqa print(e.with_traceback())
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Sorry to be a bother but I've made an alternative syntax for Jello/Jellyfish https://github.com/tom-huntington/pufferfish that depends on Jello being packaged.

If you prefer a different directory structure I could make a different PR. (to run without installing `python -m src.jello`)

I've ported some of your solutions:

| Problem | Solution |
|---------|----------|
| [3005. Count Elements With Maximum Frequency](https://leetcode.com/contest/weekly-contest-380/problems/count-elements-with-maximum-frequency/) | `\ key{len} . \ idx_max at_idx . sum` |
| [3010. Divide an Array Into Subarrays With Minimum Cost I](https://leetcode.com/contest/biweekly-contest-122/problems/divide-an-array-into-subarrays-with-minimum-cost-i/) | `\ tail sort . take 2 pair head \ flat sum` |
| [3028. Ant on the Boundary](https://leetcode.com/contest/weekly-contest-383/problems/ant-on-the-boundary/) | `\ sums = 0 sum` |
| [3038. Maximum Number of Operations With the Same Score I](https://leetcode.com/contest/biweekly-contest-124/problems/maximum-number-of-operations-with-the-same-score-i/) | `\ len idiv 2 c{take} chunk_fold(+ 2) \ = head . sum` |
| [PWC 250 - Task 1: Smallest Index](https://theweeklychallenge.org/blog/perl-weekly-challenge-250/) | `\ len iota0 . mod 10 = . \| keep head` |
| [1365. How Many Numbers Are Smaller Than the Current Number](https://leetcode.com/problems/how-many-numbers-are-smaller-than-the-current-number/description/) | `\ w(outer{<}) each(sum)` |
| [1295. Find Numbers with Even Number of Digits](https://leetcode.com/problems/find-numbers-with-even-number-of-digits/) | `\ i_to_d \ len_each \ odd? \ not sum` |
| [2859. Sum of Values at Indices With K Set Bits](https://leetcode.com/problems/sum-of-values-at-indices-with-k-set-bits/description/) | `\| (len iota0 . bits) = r * l \ sum` |



### Justification

An alternative syntax is needed for two reasons:

- **Arbitrary Nesting**: Jelly only allows one level of nesting using separators.
- **Regularity**: The combinator boundaries in Pufferfish form a regular grammar. In Jelly the combinator boundaries form a context free grammar. To determine the boundaries of a Jelly chain, you must run a pushdown automata (1 stack) inside your head. To determine the boundaries of a Pufferfish chain, you merely have to run a finite automata (0 stacks) inside your head. This considerably reduces the cognitive burden needed to understand the code.
